### PR TITLE
review_groups: remove `.all()` from review groups query (Bug 1980216)

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -427,7 +427,6 @@ def get_review_groups(sessions: Sessions) -> list[dict]:
     projects = (
         sessions.projects.query(ProjectDb.Project)
         .filter(ProjectDb.Project.name.endswith("-reviewers"))
-        .all()
     )
 
     logging.info(f"Found {projects.count()} review groups for processing.")


### PR DESCRIPTION
This keeps `projects` as a SQLAlchemy query object, so `projects.count()` works as expected.
The behaviour is the same as iterating over the query object returns the results of the query
in the list below.