### PR TITLE
Bug 2047291 - [PHAB-ETL] Expand Phabricator ETL to include project transactions to track new project and membership changes

### DIFF
--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -587,12 +587,15 @@ def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> st
 
     PHIDs that do not resolve to a user are skipped.
     """
-    names = [
-        name
-        for phid in member_phids
-        if (name := get_user_name(phid, sessions)) is not None
-    ]
-    return ",".join(sorted(names))
+    if not member_phids:
+        return ""
+
+    rows = (
+        sessions.users.query(sessions.db.user.User.userName)
+        .filter(sessions.db.user.User.phid.in_(member_phids))
+        .all()
+    )
+    return ",".join(sorted({row[0] for row in rows}))
 
 
 def get_project_transactions(sessions: Sessions) -> list[dict]:

--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -29,12 +29,16 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
 from phabricator_etl.transforms import (
+    decode_name_transaction_value,
+    is_membership_edge_transaction,
     latest_approved_date,
     latest_landed_date,
+    parse_edge_member_phids,
     parse_repository_details,
     should_include_diff,
     transform_changeset_dict,
     transform_comment_dict,
+    transform_project_transaction_dict,
     transform_review_dict,
     transform_transaction_dict,
 )
@@ -55,6 +59,14 @@ STATE_CHANGE_TYPES = [
     "differential.revision.wrong",
 ]
 
+# Project transaction types tracked in the project transactions table:
+# project creation, renames, and membership (`core:edge`) changes.
+PROJECT_TRANSACTION_TYPES = [
+    "core:create",
+    "project:name",
+    "core:edge",
+]
+
 logging.basicConfig(
     level=logging.INFO,
     format="[%(asctime)s] - {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
@@ -73,6 +85,7 @@ class Config:
     bq_review_requests_table_id: str
     bq_transactions_table_id: str
     bq_review_groups_table_id: str
+    bq_project_transactions_table_id: str
 
     phab_db_url: str
     phab_db_namespace: str
@@ -97,6 +110,7 @@ def get_config() -> Config:
         bq_review_requests_table_id=os.environ["BQ_REVIEW_REQUESTS_TABLE_ID"],
         bq_transactions_table_id=os.environ["BQ_TRANSACTIONS_TABLE_ID"],
         bq_review_groups_table_id=os.environ["BQ_REVIEW_GROUPS_TABLE_ID"],
+        bq_project_transactions_table_id=os.environ["BQ_PROJECT_TRANSACTIONS_TABLE_ID"],
         phab_db_url=os.environ.get("PHAB_URL", "127.0.0.1"),
         phab_db_namespace=os.environ.get("PHAB_NAMESPACE", "bitnami_phabricator"),
         phab_db_port=os.environ.get("PHAB_PORT", "3307"),
@@ -155,6 +169,7 @@ class Db:
             project=SimpleNamespace(
                 Project=project_classes.project,
                 Edges=project_classes.edge,
+                Transaction=project_classes.project_transaction,
             ),
             repo=SimpleNamespace(
                 Repository=repo_classes.repository,
@@ -558,6 +573,82 @@ def get_review_groups(sessions: Sessions) -> list[dict]:
     return groups
 
 
+def get_project(project_phid: str, sessions: Sessions) -> Optional[Any]:
+    """Return the project model object for a project PHID."""
+    return (
+        sessions.projects.query(sessions.db.project.Project)
+        .filter_by(phid=project_phid)
+        .first()
+    )
+
+
+def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> str:
+    """Return a sorted, comma-joined list of usernames for member PHIDs.
+
+    PHIDs that do not resolve to a user are skipped.
+    """
+    names = [
+        name
+        for phid in member_phids
+        if (name := get_user_name(phid, sessions)) is not None
+    ]
+    return ",".join(sorted(names))
+
+
+def get_project_transactions(sessions: Sessions) -> list[dict]:
+    """Return one row per tracked project transaction across all projects.
+
+    Captures project creation (`core:create`), renames (`project:name`), and
+    membership changes (`core:edge` filtered to `PROJECT_HAS_MEMBER` edges).
+    For membership changes, `old_value`/`new_value` hold the comma-joined
+    usernames removed/added by the transaction.
+    """
+    transactions = []
+
+    project_transactions = (
+        sessions.projects.query(sessions.db.project.Transaction)
+        .filter(
+            sessions.db.project.Transaction.transactionType.in_(
+                PROJECT_TRANSACTION_TYPES
+            )
+        )
+        .order_by(sessions.db.project.Transaction.dateCreated)
+    )
+
+    for transaction in project_transactions:
+        if transaction.transactionType == "core:edge":
+            if not is_membership_edge_transaction(transaction.metadata):
+                continue
+
+            old_phids = parse_edge_member_phids(transaction.oldValue)
+            new_phids = parse_edge_member_phids(transaction.newValue)
+            old_value = usernames_for_member_phids(old_phids - new_phids, sessions)
+            new_value = usernames_for_member_phids(new_phids - old_phids, sessions)
+        elif transaction.transactionType == "project:name":
+            old_value = decode_name_transaction_value(transaction.oldValue)
+            new_value = decode_name_transaction_value(transaction.newValue)
+        else:
+            # `core:create` carries no meaningful old/new value.
+            old_value = None
+            new_value = None
+
+        project = get_project(transaction.objectPHID, sessions)
+
+        transactions.append(
+            transform_project_transaction_dict(
+                transaction=transaction,
+                project_id=project.id if project else None,
+                project_name=project.name if project else None,
+                author_email=get_user_email(transaction.authorPHID, sessions),
+                author_username=get_user_name(transaction.authorPHID, sessions),
+                old_value=old_value,
+                new_value=new_value,
+            )
+        )
+
+    return transactions
+
+
 def get_revision(
     revision: Any,
     bug_id: Optional[int],
@@ -631,6 +722,9 @@ def load_bigquery_tables(
         ),
         config.bq_review_groups_table_id: bq_client.get_table(
             config.bq_review_groups_table_id
+        ),
+        config.bq_project_transactions_table_id: bq_client.get_table(
+            config.bq_project_transactions_table_id
         ),
     }
 
@@ -804,6 +898,7 @@ def merge_staging_tables(
         (config.bq_comments_table_id, "comment_id", "date_created"),
         (config.bq_transactions_table_id, "transaction_id", "date_created"),
         (config.bq_review_groups_table_id, "group_id", None),
+        (config.bq_project_transactions_table_id, "transaction_id", "date_created"),
     ):
         merge_into_bigquery(
             bq_client,
@@ -949,6 +1044,14 @@ def process():
         bq_client,
         staging_tables[config.bq_review_groups_table_id],
         review_groups,
+    )
+
+    project_transactions = get_project_transactions(sessions)
+    logging.info(f"Found {len(project_transactions)} project transactions.")
+    submit_to_bigquery(
+        bq_client,
+        staging_tables[config.bq_project_transactions_table_id],
+        project_transactions,
     )
 
     logging.info(f"Found {updated_revisions.count()} revisions for processing.")

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -208,7 +208,11 @@ def parse_edge_member_phids(value: Optional[str]) -> set[str]:
         return set()
     if isinstance(parsed, dict):
         return set(parsed.keys())
-    return set(parsed)
+    if isinstance(parsed, list):
+        return {item for item in parsed if isinstance(item, str)}
+    if isinstance(parsed, str):
+        return {parsed}
+    return set()
 
 
 def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -185,8 +185,12 @@ def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
     """
     if not metadata:
         return False
-    edge_type = json.loads(metadata).get("edge:type")
-    return edge_type == PROJECT_HAS_MEMBER_EDGE_TYPE
+
+    parsed = json.loads(metadata)
+    if not isinstance(parsed, dict):
+        return False
+
+    return parsed.get("edge:type") == PROJECT_HAS_MEMBER_EDGE_TYPE
 
 
 def parse_edge_member_phids(value: Optional[str]) -> set[str]:

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Optional
 
+# Phabricator `edge.type` for project membership (PROJECT_HAS_MEMBER). Project
+# `core:edge` transactions cover many edge kinds (watchers, etc.); only this
+# one represents a membership change.
+PROJECT_HAS_MEMBER_EDGE_TYPE = 13
+
 
 def convert_value_to_string(value: Any) -> str:
     """Coerce transaction values to string.
@@ -168,3 +173,72 @@ def parse_repository_details(target_repo: Optional[Any]) -> dict:
     if not target_repo or not target_repo.details:
         return {}
     return json.loads(target_repo.details)
+
+
+def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
+    """Return `True` for a `core:edge` transaction that changes membership.
+
+    Project `core:edge` transactions span every edge kind; the affected kind
+    is recorded as `edge:type` in the transaction's JSON `metadata`. Only
+    `PROJECT_HAS_MEMBER` edges represent membership changes. Returns `False`
+    when metadata is missing or names a different edge type.
+    """
+    if not metadata:
+        return False
+    edge_type = json.loads(metadata).get("edge:type")
+    return edge_type == PROJECT_HAS_MEMBER_EDGE_TYPE
+
+
+def parse_edge_member_phids(value: Optional[str]) -> set[str]:
+    """Return the set of member PHIDs in a `core:edge` value snapshot.
+
+    Phabricator stores edge snapshots as a JSON object keyed by destination
+    PHID, but older transactions may use a JSON list of PHIDs. Returns an
+    empty set for `None`, an empty string, or JSON `null`.
+    """
+    if not value:
+        return set()
+
+    parsed = json.loads(value)
+    if parsed is None:
+        return set()
+    if isinstance(parsed, dict):
+        return set(parsed.keys())
+    return set(parsed)
+
+
+def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:
+    """Decode a `project:name` transaction value (a JSON string), or `None`.
+
+    Returns `None` for `None`, an empty string, or JSON `null`.
+    """
+    if not value:
+        return None
+    return json.loads(value)
+
+
+def transform_project_transaction_dict(
+    transaction: Any,
+    project_id: Optional[int],
+    project_name: Optional[str],
+    author_email: Optional[str],
+    author_username: Optional[str],
+    old_value: Optional[str],
+    new_value: Optional[str],
+) -> dict:
+    """Build the output dict for a single project transaction row.
+
+    Value resolution (member PHID -> username, name decoding) happens in the
+    caller; this helper only assembles the row from already-resolved fields.
+    """
+    return {
+        "project_id": project_id,
+        "project_name": project_name,
+        "transaction_id": transaction.id,
+        "author_email": author_email,
+        "author_username": author_username,
+        "date_created": transaction.dateCreated,
+        "transaction_type": transaction.transactionType,
+        "old_value": old_value,
+        "new_value": new_value,
+    }

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -185,11 +185,9 @@ def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
     """
     if not metadata:
         return False
-
     parsed = json.loads(metadata)
     if not isinstance(parsed, dict):
         return False
-
     return parsed.get("edge:type") == PROJECT_HAS_MEMBER_EDGE_TYPE
 
 
@@ -198,31 +196,30 @@ def parse_edge_member_phids(value: Optional[str]) -> set[str]:
 
     Phabricator stores edge snapshots as a JSON object keyed by destination
     PHID, but older transactions may use a JSON list of PHIDs. Returns an
-    empty set for `None`, an empty string, or JSON `null`.
+    empty set for `None`, an empty string, JSON `null`, or any other
+    unexpected JSON shape.
     """
     if not value:
         return set()
 
     parsed = json.loads(value)
-    if parsed is None:
-        return set()
     if isinstance(parsed, dict):
         return set(parsed.keys())
     if isinstance(parsed, list):
-        return {item for item in parsed if isinstance(item, str)}
-    if isinstance(parsed, str):
-        return {parsed}
+        return {phid for phid in parsed if isinstance(phid, str)}
     return set()
 
 
 def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:
     """Decode a `project:name` transaction value (a JSON string), or `None`.
 
-    Returns `None` for `None`, an empty string, or JSON `null`.
+    Returns `None` for `None`, an empty string, JSON `null`, or a non-string
+    JSON value.
     """
     if not value:
         return None
-    return json.loads(value)
+    decoded = json.loads(value)
+    return decoded if isinstance(decoded, str) else None
 
 
 def transform_project_transaction_dict(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,118 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import json
+from types import SimpleNamespace
+
+from phabricator_etl.transforms import (
+    PROJECT_HAS_MEMBER_EDGE_TYPE,
+    decode_name_transaction_value,
+    is_membership_edge_transaction,
+    parse_edge_member_phids,
+    transform_project_transaction_dict,
+)
+
+
+def test_is_membership_edge_transaction_true_for_member_edge():
+    metadata = json.dumps({"edge:type": PROJECT_HAS_MEMBER_EDGE_TYPE})
+    assert is_membership_edge_transaction(metadata) is True
+
+
+def test_is_membership_edge_transaction_false_for_other_edge():
+    # Some non-membership edge type (e.g. watchers).
+    metadata = json.dumps({"edge:type": 42})
+    assert is_membership_edge_transaction(metadata) is False
+
+
+def test_is_membership_edge_transaction_false_for_missing_metadata():
+    assert is_membership_edge_transaction(None) is False
+    assert is_membership_edge_transaction("") is False
+    assert is_membership_edge_transaction(json.dumps({})) is False
+
+
+def test_parse_edge_member_phids_from_dict_snapshot():
+    value = json.dumps(
+        {
+            "PHID-USER-alice": {"dst": "PHID-USER-alice"},
+            "PHID-USER-bob": {"dst": "PHID-USER-bob"},
+        }
+    )
+    assert parse_edge_member_phids(value) == {"PHID-USER-alice", "PHID-USER-bob"}
+
+
+def test_parse_edge_member_phids_from_list_snapshot():
+    value = json.dumps(["PHID-USER-alice", "PHID-USER-bob"])
+    assert parse_edge_member_phids(value) == {"PHID-USER-alice", "PHID-USER-bob"}
+
+
+def test_parse_edge_member_phids_empty_and_null():
+    assert parse_edge_member_phids(None) == set()
+    assert parse_edge_member_phids("") == set()
+    assert parse_edge_member_phids("null") == set()
+
+
+def test_membership_diff_added_and_removed():
+    old = parse_edge_member_phids(
+        json.dumps({"PHID-USER-alice": {}, "PHID-USER-bob": {}})
+    )
+    new = parse_edge_member_phids(
+        json.dumps({"PHID-USER-bob": {}, "PHID-USER-carol": {}})
+    )
+    assert old - new == {"PHID-USER-alice"}  # removed
+    assert new - old == {"PHID-USER-carol"}  # added
+
+
+def test_decode_name_transaction_value():
+    assert decode_name_transaction_value(json.dumps("My Project")) == "My Project"
+    assert decode_name_transaction_value(None) is None
+    assert decode_name_transaction_value("") is None
+    assert decode_name_transaction_value("null") is None
+
+
+def test_transform_project_transaction_dict_shape():
+    transaction = SimpleNamespace(
+        id=99,
+        dateCreated=1700000000,
+        transactionType="core:edge",
+    )
+    row = transform_project_transaction_dict(
+        transaction=transaction,
+        project_id=7,
+        project_name="bmo-reviewers",
+        author_email="alice@example.com",
+        author_username="alice",
+        old_value="bob",
+        new_value="carol",
+    )
+    assert row == {
+        "project_id": 7,
+        "project_name": "bmo-reviewers",
+        "transaction_id": 99,
+        "author_email": "alice@example.com",
+        "author_username": "alice",
+        "date_created": 1700000000,
+        "transaction_type": "core:edge",
+        "old_value": "bob",
+        "new_value": "carol",
+    }
+
+
+def test_transform_project_transaction_dict_create_has_null_values():
+    transaction = SimpleNamespace(
+        id=1,
+        dateCreated=1700000000,
+        transactionType="core:create",
+    )
+    row = transform_project_transaction_dict(
+        transaction=transaction,
+        project_id=7,
+        project_name="bmo-reviewers",
+        author_email=None,
+        author_username=None,
+        old_value=None,
+        new_value=None,
+    )
+    assert row["old_value"] is None
+    assert row["new_value"] is None
+    assert row["transaction_type"] == "core:create"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2,8 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Unit tests for `phabricator_etl.transforms`."""
+
 import json
 from types import SimpleNamespace
+
+import pytest
 
 from phabricator_etl.transforms import (
     PROJECT_HAS_MEMBER_EDGE_TYPE,
@@ -11,6 +15,15 @@ from phabricator_etl.transforms import (
     is_membership_edge_transaction,
     parse_edge_member_phids,
     transform_project_transaction_dict,
+    convert_value_to_string,
+    latest_approved_date,
+    latest_landed_date,
+    parse_repository_details,
+    should_include_diff,
+    transform_changeset_dict,
+    transform_comment_dict,
+    transform_review_dict,
+    transform_transaction_dict,
 )
 
 
@@ -116,3 +129,466 @@ def test_transform_project_transaction_dict_create_has_null_values():
     assert row["old_value"] is None
     assert row["new_value"] is None
     assert row["transaction_type"] == "core:create"
+
+
+def test_convert_value_to_string_true_becomes_one():
+    assert convert_value_to_string(True) == "1", (
+        '`convert_value_to_string(True)` should return `"1"` so that '
+        "boolean transaction values round-trip into BigQuery's string column."
+    )
+
+
+def test_convert_value_to_string_false_becomes_zero():
+    assert convert_value_to_string(False) == "0", (
+        '`convert_value_to_string(False)` should return `"0"` '
+        "(the string, not the integer)."
+    )
+
+
+def test_convert_value_to_string_str_passes_through():
+    assert convert_value_to_string("already a string") == "already a string", (
+        "A string input should be returned unchanged."
+    )
+
+
+def test_convert_value_to_string_int_stringifies():
+    assert convert_value_to_string(42) == "42", (
+        "Integer inputs should be coerced to their decimal string form."
+    )
+
+
+def test_convert_value_to_string_none_stringifies():
+    assert convert_value_to_string(None) == "None", (
+        "`None` should be coerced via `str(None)` rather than special-cased; "
+        "the ETL relies on a non-null string for `oldValue`/`newValue`."
+    )
+
+
+def test_convert_value_to_string_empty_string_passes_through():
+    assert convert_value_to_string("") == "", (
+        "Empty strings should remain empty rather than being coerced to another value."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `transform_changeset_dict`
+# ---------------------------------------------------------------------------
+
+
+def test_transform_changeset_dict_decodes_filename_from_bytes():
+    changeset = SimpleNamespace(
+        id=4242,
+        addLines=12,
+        delLines=3,
+        filename=b"path/to/file.py",
+    )
+
+    result = transform_changeset_dict(changeset, revision_id=10, diff_id=99)
+
+    assert result == {
+        "revision_id": 10,
+        "diff_id": 99,
+        "changeset_id": 4242,
+        "lines_added": 12,
+        "lines_removed": 3,
+        "filename": "path/to/file.py",
+    }, (
+        "`transform_changeset_dict` should map the changeset row's columns "
+        "into the BigQuery row dict and UTF-8 decode the byte-string "
+        "filename."
+    )
+
+
+def test_transform_changeset_dict_decodes_non_ascii_filename():
+    changeset = SimpleNamespace(
+        id=1,
+        addLines=0,
+        delLines=0,
+        filename="café.py".encode("utf-8"),
+    )
+
+    result = transform_changeset_dict(changeset, revision_id=1, diff_id=1)
+
+    assert result["filename"] == "café.py", (
+        "Non-ASCII filenames stored as UTF-8 bytes should round-trip back "
+        "to their unicode form."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `transform_comment_dict`
+# ---------------------------------------------------------------------------
+
+
+def test_transform_comment_dict_detects_inline_suggestion():
+    comment = SimpleNamespace(
+        id=7,
+        changesetID=33,
+        dateCreated=1_700_000_000,
+        content="Consider renaming this variable.",
+        attributes=json.dumps({"inline.state.initial": {"hassuggestion": "true"}}),
+    )
+
+    result = transform_comment_dict(
+        comment,
+        revision_id=42,
+        diff_id=8,
+        author_email="alice@example.com",
+        author_username="alice",
+    )
+
+    assert result == {
+        "revision_id": 42,
+        "diff_id": 8,
+        "changeset_id": 33,
+        "comment_id": 7,
+        "author_email": "alice@example.com",
+        "author_username": "alice",
+        "date_created": 1_700_000_000,
+        "character_count": len("Consider renaming this variable."),
+        "is_suggestion": True,
+    }, (
+        "A comment whose `attributes.inline.state.initial.hassuggestion` "
+        'is the string `"true"` should produce `is_suggestion=True` and '
+        "map every other field into the output row."
+    )
+
+
+def test_transform_comment_dict_marks_non_suggestion_as_false():
+    comment = SimpleNamespace(
+        id=2,
+        changesetID=None,
+        dateCreated=1,
+        content="lgtm",
+        attributes=json.dumps({}),
+    )
+
+    result = transform_comment_dict(
+        comment,
+        revision_id=1,
+        diff_id=None,
+        author_email=None,
+        author_username=None,
+    )
+
+    assert result["is_suggestion"] is False, (
+        "A comment with no `inline.state.initial` block should be "
+        "classified as a regular comment (`is_suggestion=False`)."
+    )
+    assert result["character_count"] == len("lgtm"), (
+        "`character_count` should be the length of `comment.content` "
+        "regardless of whether the comment is a suggestion."
+    )
+
+
+def test_transform_comment_dict_suggestion_flag_only_true_for_literal_string():
+    # Phab stores the suggestion flag as a string, not a bool.
+    comment = SimpleNamespace(
+        id=3,
+        changesetID=1,
+        dateCreated=0,
+        content="",
+        attributes=json.dumps({"inline.state.initial": {"hassuggestion": True}}),
+    )
+
+    result = transform_comment_dict(
+        comment,
+        revision_id=1,
+        diff_id=1,
+        author_email=None,
+        author_username=None,
+    )
+
+    assert result["is_suggestion"] is False, (
+        "Boolean `True` for `hassuggestion` should not be treated as a "
+        "suggestion. The Phabricator schema stores the flag as the literal "
+        'string `"true"`, and matching that exactly is what the ETL '
+        "promises."
+    )
+
+
+def test_transform_comment_dict_malformed_attributes_raises():
+    comment = SimpleNamespace(
+        id=1,
+        changesetID=None,
+        dateCreated=0,
+        content="",
+        attributes="not-json",
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        transform_comment_dict(
+            comment,
+            revision_id=1,
+            diff_id=None,
+            author_email=None,
+            author_username=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# `transform_transaction_dict`
+# ---------------------------------------------------------------------------
+
+
+def test_transform_transaction_dict_maps_fields_and_stringifies_values():
+    transaction = SimpleNamespace(
+        id=11,
+        transactionType="differential.revision.accept",
+        oldValue="0",
+        newValue="2",
+        dateCreated=1_700_000_000,
+    )
+
+    result = transform_transaction_dict(
+        transaction,
+        revision_id=99,
+        author_email="bob@example.com",
+        author_username="bob",
+    )
+
+    assert result == {
+        "revision_id": 99,
+        "transaction_id": 11,
+        "transaction_type": "differential.revision.accept",
+        "author_email": "bob@example.com",
+        "author_username": "bob",
+        "date_created": 1_700_000_000,
+        "old_value": "0",
+        "new_value": "2",
+    }, (
+        "`transform_transaction_dict` should map every column straight "
+        "through, using `convert_value_to_string` on the old/new values."
+    )
+
+
+def test_transform_transaction_dict_coerces_boolean_values():
+    transaction = SimpleNamespace(
+        id=1,
+        transactionType="differential.revision.close",
+        oldValue=False,
+        newValue=True,
+        dateCreated=0,
+    )
+
+    result = transform_transaction_dict(
+        transaction,
+        revision_id=1,
+        author_email=None,
+        author_username=None,
+    )
+
+    assert (result["old_value"], result["new_value"]) == ("0", "1"), (
+        "Boolean `oldValue`/`newValue` should round-trip through "
+        '`convert_value_to_string`, becoming `"0"`/`"1"`.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# `should_include_diff`
+# ---------------------------------------------------------------------------
+
+
+def test_should_include_diff_excludes_commit_method():
+    diff = SimpleNamespace(creationMethod="commit", authorPHID=b"PHID-USER-x")
+    assert should_include_diff(diff) is False, (
+        'Diffs whose `creationMethod` is `"commit"` represent landings '
+        "and must be filtered out of the diffs table (they only contribute "
+        "to `date_landed`)."
+    )
+
+
+def test_should_include_diff_excludes_repository_identity_author():
+    diff = SimpleNamespace(creationMethod="web", authorPHID=b"PHID-RIDT-abc")
+    assert should_include_diff(diff) is False, (
+        "Diffs authored by a repository identity (`PHID-RIDT-*`) are "
+        "bookkeeping artifacts and must be filtered out."
+    )
+
+
+def test_should_include_diff_keeps_normal_diffs():
+    diff = SimpleNamespace(creationMethod="web", authorPHID=b"PHID-USER-abc")
+    assert should_include_diff(diff) is True, (
+        "A web-uploaded diff authored by a regular user should be included."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `latest_landed_date`
+# ---------------------------------------------------------------------------
+
+
+def test_latest_landed_date_empty_input_is_none():
+    assert latest_landed_date([]) is None, (
+        "With no diffs there is no landing date to report."
+    )
+
+
+def test_latest_landed_date_ignores_non_commit_diffs():
+    diffs = [
+        SimpleNamespace(creationMethod="web", dateCreated=999),
+        SimpleNamespace(creationMethod="raw", dateCreated=888),
+    ]
+    assert latest_landed_date(diffs) is None, (
+        'Only `creationMethod == "commit"` diffs feed `date_landed`; '
+        "non-commit diffs must not contribute even if they have a later "
+        "`dateCreated`."
+    )
+
+
+def test_latest_landed_date_returns_max_of_commit_diffs():
+    diffs = [
+        SimpleNamespace(creationMethod="commit", dateCreated=100),
+        SimpleNamespace(creationMethod="commit", dateCreated=300),
+        SimpleNamespace(creationMethod="commit", dateCreated=200),
+        SimpleNamespace(creationMethod="web", dateCreated=999),
+    ]
+    assert latest_landed_date(diffs) == 300, (
+        "`latest_landed_date` should return the maximum `dateCreated` "
+        "among the commit-method diffs, ignoring the unrelated web diff "
+        "even though its date is larger."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `transform_review_dict`
+# ---------------------------------------------------------------------------
+
+
+def test_transform_review_dict_maps_user_reviewer_fields():
+    review = SimpleNamespace(
+        id=55,
+        reviewerStatus="accepted",
+        dateCreated=1_700_000_000,
+        dateModified=1_700_000_500,
+    )
+
+    result = transform_review_dict(
+        review,
+        revision_id=99,
+        reviewer_username="alice",
+        reviewer_email="alice@example.com",
+        is_group=False,
+        last_action_diff_id=12,
+        last_comment_diff_id=11,
+    )
+
+    assert result == {
+        "revision_id": 99,
+        "review_id": 55,
+        "reviewer_username": "alice",
+        "reviewer_email": "alice@example.com",
+        "is_group": False,
+        "date_created": 1_700_000_000,
+        "date_modified": 1_700_000_500,
+        "status": "accepted",
+        "last_action_diff_id": 12,
+        "last_comment_diff_id": 11,
+    }, (
+        "User reviews should map review and reviewer fields straight "
+        "into the output row."
+    )
+
+
+def test_transform_review_dict_handles_group_reviewer():
+    review = SimpleNamespace(
+        id=1,
+        reviewerStatus="added",
+        dateCreated=0,
+        dateModified=0,
+    )
+
+    result = transform_review_dict(
+        review,
+        revision_id=1,
+        reviewer_username="conduit-reviewers",
+        reviewer_email=None,
+        is_group=True,
+        last_action_diff_id=None,
+        last_comment_diff_id=None,
+    )
+
+    assert result["is_group"] is True, (
+        "Group reviewers should be flagged with `is_group=True`."
+    )
+    assert result["reviewer_email"] is None, (
+        "Group reviewers have no email; the field should be `None` rather "
+        "than missing from the row."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `latest_approved_date`
+# ---------------------------------------------------------------------------
+
+
+def test_latest_approved_date_empty_input_is_none():
+    assert latest_approved_date([]) is None, (
+        "With no reviews there is no approval date."
+    )
+
+
+def test_latest_approved_date_ignores_non_accepted_reviews():
+    reviews = [
+        SimpleNamespace(reviewerStatus="rejected", dateModified=999),
+        SimpleNamespace(reviewerStatus="added", dateModified=888),
+        SimpleNamespace(reviewerStatus="commented", dateModified=777),
+    ]
+    assert latest_approved_date(reviews) is None, (
+        "Only `accepted` reviews count toward the approval date; rejected "
+        "and pending reviews must not contribute."
+    )
+
+
+def test_latest_approved_date_returns_max_modified_of_accepted():
+    reviews = [
+        SimpleNamespace(reviewerStatus="accepted", dateModified=100),
+        SimpleNamespace(reviewerStatus="accepted", dateModified=300),
+        SimpleNamespace(reviewerStatus="rejected", dateModified=999),
+        SimpleNamespace(reviewerStatus="accepted", dateModified=200),
+    ]
+    assert latest_approved_date(reviews) == 300, (
+        "The latest `dateModified` among `accepted` reviews wins; the "
+        "later `rejected` review must be ignored."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `parse_repository_details`
+# ---------------------------------------------------------------------------
+
+
+def test_parse_repository_details_returns_empty_dict_for_none_repo():
+    assert parse_repository_details(None) == {}, (
+        "A missing repository should produce an empty dict rather than "
+        "raising; downstream `.get(...)` calls treat it as no details."
+    )
+
+
+def test_parse_repository_details_returns_empty_dict_for_blank_details():
+    target_repo = SimpleNamespace(details=None)
+    assert parse_repository_details(target_repo) == {}, (
+        "A repository with `details=None` should produce an empty dict."
+    )
+
+    target_repo = SimpleNamespace(details="")
+    assert parse_repository_details(target_repo) == {}, (
+        'A repository with `details=""` (falsy empty string) should '
+        'also produce an empty dict; we never call `json.loads("")`.'
+    )
+
+
+def test_parse_repository_details_parses_valid_json():
+    target_repo = SimpleNamespace(
+        details=json.dumps({"default-branch": "main", "other": 42})
+    )
+    assert parse_repository_details(target_repo) == {
+        "default-branch": "main",
+        "other": 42,
+    }, "A populated `details` JSON column should be parsed into a dict."
+
+
+def test_parse_repository_details_raises_on_malformed_json():
+    target_repo = SimpleNamespace(details="not-json")
+    with pytest.raises(json.JSONDecodeError):
+        parse_repository_details(target_repo)


### PR DESCRIPTION
Summary

Added project-transaction tracking to the ETL, populating a new metrics_project_transactions BigQuery table.

phabricator_etl/transforms.py (pure, unit-tested):
- PROJECT_HAS_MEMBER_EDGE_TYPE = 13 constant
- is_membership_edge_transaction() — filters core:edge transactions to membership edges via metadata["edge:type"]
- parse_edge_member_phids() — extracts member PHIDs from a JSON edge snapshot (handles dict, list, null/empty)
- decode_name_transaction_value() — decodes the JSON-encoded project:name value
- transform_project_transaction_dict() — assembles the 9-field row from already-resolved values

phabricator_etl/stats.py:
- New Db ORM class project.Transaction → project_transaction
- PROJECT_TRANSACTION_TYPES = ["core:create", "project:name", "core:edge"]
- New BQ_PROJECT_TRANSACTIONS_TABLE_ID config/env var, wired into load_bigquery_tables and merge_staging_tables (merge key transaction_id)
- get_project_transactions() + helpers get_project() / usernames_for_member_phids(). For membership changes, old_value/new_value hold comma-joined usernames removed/added (the added/removed diff you chose); renames decode the name; core:create carries null values
- Submitted once per run beside get_review_groups (the full-snapshot cadence you chose)

tests/test_transforms.py — 10 new tests

Verification: ruff check, ruff format --check, and pytest (12 passed) all green — run via a sibling venv since this repo pins Python 3.9.16, which isn't installed here.

Two things to flag before this can ship

1. External infra dependency (out of scope for this repo): the actual BigQuery table and its terraform bq_metrics_transactions_schema (the jsonencode([...]) from comment 1) must be created in the infra repo before deploy — this repo only reads existing tables via get_table, so the ETL will raise on startup until BQ_PROJECT_TRANSACTIONS_TABLE_ID points at a real table.
2. date_created is emitted as the raw Phabricator epoch int. BigQuery coerces epoch-seconds into a TIMESTAMP column on insert_rows_json; if the live table rejects it, the fix is a one-line RFC3339 conversion in the transform. Worth confirming on first run against the real table.