### PR TITLE
Bug 2047291 - [PHAB-ETL] Expand Phabricator ETL to include project transactions to track new project and membership changes

### DIFF
--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -29,12 +29,16 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
 from phabricator_etl.transforms import (
+    decode_name_transaction_value,
+    is_membership_edge_transaction,
     latest_approved_date,
     latest_landed_date,
+    parse_edge_member_phids,
     parse_repository_details,
     should_include_diff,
     transform_changeset_dict,
     transform_comment_dict,
+    transform_project_transaction_dict,
     transform_review_dict,
     transform_transaction_dict,
 )
@@ -55,6 +59,14 @@ STATE_CHANGE_TYPES = [
     "differential.revision.wrong",
 ]
 
+# Project transaction types tracked in the project transactions table:
+# project creation, renames, and membership (`core:edge`) changes.
+PROJECT_TRANSACTION_TYPES = [
+    "core:create",
+    "project:name",
+    "core:edge",
+]
+
 logging.basicConfig(
     level=logging.INFO,
     format="[%(asctime)s] - {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
@@ -73,6 +85,7 @@ class Config:
     bq_review_requests_table_id: str
     bq_transactions_table_id: str
     bq_review_groups_table_id: str
+    bq_project_transactions_table_id: str
 
     phab_db_url: str
     phab_db_namespace: str
@@ -97,6 +110,7 @@ def get_config() -> Config:
         bq_review_requests_table_id=os.environ["BQ_REVIEW_REQUESTS_TABLE_ID"],
         bq_transactions_table_id=os.environ["BQ_TRANSACTIONS_TABLE_ID"],
         bq_review_groups_table_id=os.environ["BQ_REVIEW_GROUPS_TABLE_ID"],
+        bq_project_transactions_table_id=os.environ["BQ_PROJECT_TRANSACTIONS_TABLE_ID"],
         phab_db_url=os.environ.get("PHAB_URL", "127.0.0.1"),
         phab_db_namespace=os.environ.get("PHAB_NAMESPACE", "bitnami_phabricator"),
         phab_db_port=os.environ.get("PHAB_PORT", "3307"),
@@ -155,6 +169,7 @@ class Db:
             project=SimpleNamespace(
                 Project=project_classes.project,
                 Edges=project_classes.edge,
+                Transaction=project_classes.project_transaction,
             ),
             repo=SimpleNamespace(
                 Repository=repo_classes.repository,
@@ -558,6 +573,85 @@ def get_review_groups(sessions: Sessions) -> list[dict]:
     return groups
 
 
+def get_project(project_phid: str, sessions: Sessions) -> Optional[Any]:
+    """Return the project model object for a project PHID."""
+    return (
+        sessions.projects.query(sessions.db.project.Project)
+        .filter_by(phid=project_phid)
+        .first()
+    )
+
+
+def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> str:
+    """Return a sorted, comma-joined list of usernames for member PHIDs.
+
+    PHIDs that do not resolve to a user are skipped.
+    """
+    if not member_phids:
+        return ""
+
+    rows = (
+        sessions.users.query(sessions.db.user.User.userName)
+        .filter(sessions.db.user.User.phid.in_(member_phids))
+        .all()
+    )
+    return ",".join(sorted({row[0] for row in rows}))
+
+
+def get_project_transactions(sessions: Sessions) -> list[dict]:
+    """Return one row per tracked project transaction across all projects.
+
+    Captures project creation (`core:create`), renames (`project:name`), and
+    membership changes (`core:edge` filtered to `PROJECT_HAS_MEMBER` edges).
+    For membership changes, `old_value`/`new_value` hold the comma-joined
+    usernames removed/added by the transaction.
+    """
+    transactions = []
+
+    project_transactions = (
+        sessions.projects.query(sessions.db.project.Transaction)
+        .filter(
+            sessions.db.project.Transaction.transactionType.in_(
+                PROJECT_TRANSACTION_TYPES
+            )
+        )
+        .order_by(sessions.db.project.Transaction.dateCreated)
+    )
+
+    for transaction in project_transactions:
+        if transaction.transactionType == "core:edge":
+            if not is_membership_edge_transaction(transaction.metadata):
+                continue
+
+            old_phids = parse_edge_member_phids(transaction.oldValue)
+            new_phids = parse_edge_member_phids(transaction.newValue)
+            old_value = usernames_for_member_phids(old_phids - new_phids, sessions)
+            new_value = usernames_for_member_phids(new_phids - old_phids, sessions)
+        elif transaction.transactionType == "project:name":
+            old_value = decode_name_transaction_value(transaction.oldValue)
+            new_value = decode_name_transaction_value(transaction.newValue)
+        else:
+            # `core:create` carries no meaningful old/new value.
+            old_value = None
+            new_value = None
+
+        project = get_project(transaction.objectPHID, sessions)
+
+        transactions.append(
+            transform_project_transaction_dict(
+                transaction=transaction,
+                project_id=project.id if project else None,
+                project_name=project.name if project else None,
+                author_email=get_user_email(transaction.authorPHID, sessions),
+                author_username=get_user_name(transaction.authorPHID, sessions),
+                old_value=old_value,
+                new_value=new_value,
+            )
+        )
+
+    return transactions
+
+
 def get_revision(
     revision: Any,
     bug_id: Optional[int],
@@ -631,6 +725,9 @@ def load_bigquery_tables(
         ),
         config.bq_review_groups_table_id: bq_client.get_table(
             config.bq_review_groups_table_id
+        ),
+        config.bq_project_transactions_table_id: bq_client.get_table(
+            config.bq_project_transactions_table_id
         ),
     }
 
@@ -804,6 +901,7 @@ def merge_staging_tables(
         (config.bq_comments_table_id, "comment_id", "date_created"),
         (config.bq_transactions_table_id, "transaction_id", "date_created"),
         (config.bq_review_groups_table_id, "group_id", None),
+        (config.bq_project_transactions_table_id, "transaction_id", "date_created"),
     ):
         merge_into_bigquery(
             bq_client,
@@ -949,6 +1047,14 @@ def process():
         bq_client,
         staging_tables[config.bq_review_groups_table_id],
         review_groups,
+    )
+
+    project_transactions = get_project_transactions(sessions)
+    logging.info(f"Found {len(project_transactions)} project transactions.")
+    submit_to_bigquery(
+        bq_client,
+        staging_tables[config.bq_project_transactions_table_id],
+        project_transactions,
     )
 
     logging.info(f"Found {updated_revisions.count()} revisions for processing.")

--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -15,7 +15,6 @@ import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from enum import IntEnum
 from types import SimpleNamespace
 from typing import Any, Optional
 
@@ -29,6 +28,7 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
 from phabricator_etl.transforms import (
+    PhabricatorEdgeConstant,
     decode_name_transaction_value,
     is_membership_edge_transaction,
     latest_approved_date,
@@ -63,8 +63,8 @@ STATE_CHANGE_TYPES = [
 # project creation, renames, and membership (`core:edge`) changes.
 PROJECT_TRANSACTION_TYPES = [
     "core:create",
-    "project:name",
     "core:edge",
+    "project:name",
 ]
 
 logging.basicConfig(
@@ -277,15 +277,6 @@ def get_bug_id(revision: Any, sessions: Sessions, bug_id_query: Any) -> Optional
         return None
 
     return bug_id_query_result.fieldValue or None
-
-
-class PhabricatorEdgeConstant(IntEnum):
-    """Phabricator `edge.type` constants used to walk project/dependency graphs."""
-
-    DEPENDS_ON = 5
-    DEPENDED_ON = 6
-    OBJECT_HAS_PROJECT = 41
-    PROJECT_HAS_MEMBER = 13
 
 
 def get_revision_projects(
@@ -582,20 +573,20 @@ def get_project(project_phid: str, sessions: Sessions) -> Optional[Any]:
     )
 
 
-def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> str:
-    """Return a sorted, comma-joined list of usernames for member PHIDs.
+def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> list[str]:
+    """Return a sorted list of usernames for member PHIDs.
 
     PHIDs that do not resolve to a user are skipped.
     """
     if not member_phids:
-        return ""
+        return []
 
     rows = (
         sessions.users.query(sessions.db.user.User.userName)
         .filter(sessions.db.user.User.phid.in_(member_phids))
         .all()
     )
-    return ",".join(sorted({row[0] for row in rows}))
+    return sorted({row[0] for row in rows})
 
 
 def get_project_transactions(sessions: Sessions) -> list[dict]:
@@ -603,7 +594,7 @@ def get_project_transactions(sessions: Sessions) -> list[dict]:
 
     Captures project creation (`core:create`), renames (`project:name`), and
     membership changes (`core:edge` filtered to `PROJECT_HAS_MEMBER` edges).
-    For membership changes, `old_value`/`new_value` hold the comma-joined
+    For membership changes, `old_value`/`new_value` hold the lists of
     usernames removed/added by the transaction.
     """
     transactions = []
@@ -619,6 +610,8 @@ def get_project_transactions(sessions: Sessions) -> list[dict]:
     )
 
     for transaction in project_transactions:
+        project = get_project(transaction.objectPHID, sessions)
+
         if transaction.transactionType == "core:edge":
             if not is_membership_edge_transaction(transaction.metadata):
                 continue
@@ -631,11 +624,10 @@ def get_project_transactions(sessions: Sessions) -> list[dict]:
             old_value = decode_name_transaction_value(transaction.oldValue)
             new_value = decode_name_transaction_value(transaction.newValue)
         else:
-            # `core:create` carries no meaningful old/new value.
-            old_value = None
-            new_value = None
-
-        project = get_project(transaction.objectPHID, sessions)
+            # `core:create` marks the project's creation: there is no prior
+            # value, and the new value is the name of the newly created project.
+            old_value = []
+            new_value = [project.name] if project else []
 
         transactions.append(
             transform_project_transaction_dict(

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -218,7 +218,10 @@ def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:
     """
     if not value:
         return None
-    decoded = json.loads(value)
+    try:
+        decoded = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return None
     return decoded if isinstance(decoded, str) else None
 
 

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -185,10 +185,18 @@ def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
     """
     if not metadata:
         return False
-    parsed = json.loads(metadata)
+    try:
+        parsed = json.loads(metadata)
+    except (TypeError, json.JSONDecodeError):
+        return False
     if not isinstance(parsed, dict):
         return False
-    return parsed.get("edge:type") == PROJECT_HAS_MEMBER_EDGE_TYPE
+    edge_type = parsed.get("edge:type")
+    try:
+        edge_type_int = int(edge_type)
+    except (TypeError, ValueError):
+        return False
+    return edge_type_int == PROJECT_HAS_MEMBER_EDGE_TYPE
 
 
 def parse_edge_member_phids(value: Optional[str]) -> set[str]:

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -13,25 +13,30 @@ unit-testable. Functions that actually query the database live in
 from __future__ import annotations
 
 import json
+from enum import IntEnum
 from typing import Any, Iterable, Optional
 
-# Phabricator `edge.type` for project membership (PROJECT_HAS_MEMBER). Project
-# `core:edge` transactions cover many edge kinds (watchers, etc.); only this
-# one represents a membership change.
-PROJECT_HAS_MEMBER_EDGE_TYPE = 13
+
+class PhabricatorEdgeConstant(IntEnum):
+    """Phabricator `edge.type` constants used to walk project/dependency graphs."""
+
+    DEPENDS_ON = 5
+    DEPENDED_ON = 6
+    OBJECT_HAS_PROJECT = 41
+    PROJECT_HAS_MEMBER = 13
 
 
-def convert_value_to_string(value: Any) -> str:
-    """Coerce transaction values to string.
+def convert_value_to_string_list(value: Any) -> list[str]:
+    """Coerce a transaction value to a list of strings for a REPEATED field.
 
-    If the passed value is a boolean, then we convert it to the string
-    `"1"` or `"0"`. Otherwise we return it as a string.
+    If the passed value is a boolean, then we convert it to `["1"]` or
+    `["0"]`. Otherwise we wrap its string form in a single-element list.
     """
     if isinstance(value, bool):
-        # `"1"` for `True`, `"0"` for `False`.
-        return str(int(value))
+        # `["1"]` for `True`, `["0"]` for `False`.
+        return [str(int(value))]
 
-    return str(value)
+    return [str(value)]
 
 
 def transform_changeset_dict(
@@ -96,8 +101,8 @@ def transform_transaction_dict(
         "author_email": author_email,
         "author_username": author_username,
         "date_created": transaction.dateCreated,
-        "old_value": convert_value_to_string(transaction.oldValue),
-        "new_value": convert_value_to_string(transaction.newValue),
+        "old_value": convert_value_to_string_list(transaction.oldValue),
+        "new_value": convert_value_to_string_list(transaction.newValue),
     }
 
 
@@ -196,7 +201,7 @@ def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
         edge_type_int = int(edge_type)
     except (TypeError, ValueError):
         return False
-    return edge_type_int == PROJECT_HAS_MEMBER_EDGE_TYPE
+    return edge_type_int == PhabricatorEdgeConstant.PROJECT_HAS_MEMBER.value
 
 
 def parse_edge_member_phids(value: Optional[str]) -> set[str]:
@@ -222,19 +227,19 @@ def parse_edge_member_phids(value: Optional[str]) -> set[str]:
     return set()
 
 
-def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:
-    """Decode a `project:name` transaction value (a JSON string), or `None`.
+def decode_name_transaction_value(value: Optional[str]) -> list[str]:
+    """Decode a `project:name` transaction value into a list of strings.
 
-    Returns `None` for `None`, an empty string, JSON `null`, or a non-string
-    JSON value.
+    Returns `[]` for `None`, an empty string, JSON `null`, or a non-string
+    JSON value; otherwise a single-element list holding the decoded name.
     """
     if not value:
-        return None
+        return []
     try:
         decoded = json.loads(value)
     except (TypeError, json.JSONDecodeError):
-        return None
-    return decoded if isinstance(decoded, str) else None
+        return []
+    return [decoded] if isinstance(decoded, str) else []
 
 
 def transform_project_transaction_dict(
@@ -243,8 +248,8 @@ def transform_project_transaction_dict(
     project_name: Optional[str],
     author_email: Optional[str],
     author_username: Optional[str],
-    old_value: Optional[str],
-    new_value: Optional[str],
+    old_value: list[str],
+    new_value: list[str],
 ) -> dict:
     """Build the output dict for a single project transaction row.
 

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Optional
 
+# Phabricator `edge.type` for project membership (PROJECT_HAS_MEMBER). Project
+# `core:edge` transactions cover many edge kinds (watchers, etc.); only this
+# one represents a membership change.
+PROJECT_HAS_MEMBER_EDGE_TYPE = 13
+
 
 def convert_value_to_string(value: Any) -> str:
     """Coerce transaction values to string.
@@ -168,3 +173,77 @@ def parse_repository_details(target_repo: Optional[Any]) -> dict:
     if not target_repo or not target_repo.details:
         return {}
     return json.loads(target_repo.details)
+
+
+def is_membership_edge_transaction(metadata: Optional[str]) -> bool:
+    """Return `True` for a `core:edge` transaction that changes membership.
+
+    Project `core:edge` transactions span every edge kind; the affected kind
+    is recorded as `edge:type` in the transaction's JSON `metadata`. Only
+    `PROJECT_HAS_MEMBER` edges represent membership changes. Returns `False`
+    when metadata is missing or names a different edge type.
+    """
+    if not metadata:
+        return False
+    parsed = json.loads(metadata)
+    if not isinstance(parsed, dict):
+        return False
+    return parsed.get("edge:type") == PROJECT_HAS_MEMBER_EDGE_TYPE
+
+
+def parse_edge_member_phids(value: Optional[str]) -> set[str]:
+    """Return the set of member PHIDs in a `core:edge` value snapshot.
+
+    Phabricator stores edge snapshots as a JSON object keyed by destination
+    PHID, but older transactions may use a JSON list of PHIDs. Returns an
+    empty set for `None`, an empty string, JSON `null`, or any other
+    unexpected JSON shape.
+    """
+    if not value:
+        return set()
+
+    parsed = json.loads(value)
+    if isinstance(parsed, dict):
+        return set(parsed.keys())
+    if isinstance(parsed, list):
+        return {phid for phid in parsed if isinstance(phid, str)}
+    return set()
+
+
+def decode_name_transaction_value(value: Optional[str]) -> Optional[str]:
+    """Decode a `project:name` transaction value (a JSON string), or `None`.
+
+    Returns `None` for `None`, an empty string, JSON `null`, or a non-string
+    JSON value.
+    """
+    if not value:
+        return None
+    decoded = json.loads(value)
+    return decoded if isinstance(decoded, str) else None
+
+
+def transform_project_transaction_dict(
+    transaction: Any,
+    project_id: Optional[int],
+    project_name: Optional[str],
+    author_email: Optional[str],
+    author_username: Optional[str],
+    old_value: Optional[str],
+    new_value: Optional[str],
+) -> dict:
+    """Build the output dict for a single project transaction row.
+
+    Value resolution (member PHID -> username, name decoding) happens in the
+    caller; this helper only assembles the row from already-resolved fields.
+    """
+    return {
+        "project_id": project_id,
+        "project_name": project_name,
+        "transaction_id": transaction.id,
+        "author_email": author_email,
+        "author_username": author_username,
+        "date_created": transaction.dateCreated,
+        "transaction_type": transaction.transactionType,
+        "old_value": old_value,
+        "new_value": new_value,
+    }

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -210,9 +210,13 @@ def parse_edge_member_phids(value: Optional[str]) -> set[str]:
     if not value:
         return set()
 
-    parsed = json.loads(value)
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return set()
+
     if isinstance(parsed, dict):
-        return set(parsed.keys())
+        return {k for k in parsed.keys() if isinstance(k, str)}
     if isinstance(parsed, list):
         return {phid for phid in parsed if isinstance(phid, str)}
     return set()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,12 +10,12 @@ from types import SimpleNamespace
 import pytest
 
 from phabricator_etl.transforms import (
-    PROJECT_HAS_MEMBER_EDGE_TYPE,
+    PhabricatorEdgeConstant,
     decode_name_transaction_value,
     is_membership_edge_transaction,
     parse_edge_member_phids,
     transform_project_transaction_dict,
-    convert_value_to_string,
+    convert_value_to_string_list,
     latest_approved_date,
     latest_landed_date,
     parse_repository_details,
@@ -28,7 +28,9 @@ from phabricator_etl.transforms import (
 
 
 def test_is_membership_edge_transaction_true_for_member_edge():
-    metadata = json.dumps({"edge:type": PROJECT_HAS_MEMBER_EDGE_TYPE})
+    metadata = json.dumps(
+        {"edge:type": PhabricatorEdgeConstant.PROJECT_HAS_MEMBER.value}
+    )
     assert is_membership_edge_transaction(metadata) is True
 
 
@@ -77,10 +79,10 @@ def test_membership_diff_added_and_removed():
 
 
 def test_decode_name_transaction_value():
-    assert decode_name_transaction_value(json.dumps("My Project")) == "My Project"
-    assert decode_name_transaction_value(None) is None
-    assert decode_name_transaction_value("") is None
-    assert decode_name_transaction_value("null") is None
+    assert decode_name_transaction_value(json.dumps("My Project")) == ["My Project"]
+    assert decode_name_transaction_value(None) == []
+    assert decode_name_transaction_value("") == []
+    assert decode_name_transaction_value("null") == []
 
 
 def test_transform_project_transaction_dict_shape():
@@ -95,8 +97,8 @@ def test_transform_project_transaction_dict_shape():
         project_name="bmo-reviewers",
         author_email="alice@example.com",
         author_username="alice",
-        old_value="bob",
-        new_value="carol",
+        old_value=["bob"],
+        new_value=["carol"],
     )
     assert row == {
         "project_id": 7,
@@ -106,12 +108,12 @@ def test_transform_project_transaction_dict_shape():
         "author_username": "alice",
         "date_created": 1700000000,
         "transaction_type": "core:edge",
-        "old_value": "bob",
-        "new_value": "carol",
+        "old_value": ["bob"],
+        "new_value": ["carol"],
     }
 
 
-def test_transform_project_transaction_dict_create_has_null_values():
+def test_transform_project_transaction_dict_create_has_new_name_only():
     transaction = SimpleNamespace(
         id=1,
         dateCreated=1700000000,
@@ -123,49 +125,50 @@ def test_transform_project_transaction_dict_create_has_null_values():
         project_name="bmo-reviewers",
         author_email=None,
         author_username=None,
-        old_value=None,
-        new_value=None,
+        # `core:create` has no prior value; the new value is the project name.
+        old_value=[],
+        new_value=["bmo-reviewers"],
     )
-    assert row["old_value"] is None
-    assert row["new_value"] is None
+    assert row["old_value"] == []
+    assert row["new_value"] == ["bmo-reviewers"]
     assert row["transaction_type"] == "core:create"
 
 
-def test_convert_value_to_string_true_becomes_one():
-    assert convert_value_to_string(True) == "1", (
-        '`convert_value_to_string(True)` should return `"1"` so that '
-        "boolean transaction values round-trip into BigQuery's string column."
+def test_convert_value_to_string_list_true_becomes_one():
+    assert convert_value_to_string_list(True) == ["1"], (
+        '`convert_value_to_string_list(True)` should return `["1"]` so that '
+        "boolean transaction values round-trip into BigQuery's REPEATED column."
     )
 
 
-def test_convert_value_to_string_false_becomes_zero():
-    assert convert_value_to_string(False) == "0", (
-        '`convert_value_to_string(False)` should return `"0"` '
+def test_convert_value_to_string_list_false_becomes_zero():
+    assert convert_value_to_string_list(False) == ["0"], (
+        '`convert_value_to_string_list(False)` should return `["0"]` '
         "(the string, not the integer)."
     )
 
 
-def test_convert_value_to_string_str_passes_through():
-    assert convert_value_to_string("already a string") == "already a string", (
-        "A string input should be returned unchanged."
+def test_convert_value_to_string_list_str_passes_through():
+    assert convert_value_to_string_list("already a string") == ["already a string"], (
+        "A string input should be wrapped in a single-element list unchanged."
     )
 
 
-def test_convert_value_to_string_int_stringifies():
-    assert convert_value_to_string(42) == "42", (
+def test_convert_value_to_string_list_int_stringifies():
+    assert convert_value_to_string_list(42) == ["42"], (
         "Integer inputs should be coerced to their decimal string form."
     )
 
 
-def test_convert_value_to_string_none_stringifies():
-    assert convert_value_to_string(None) == "None", (
+def test_convert_value_to_string_list_none_stringifies():
+    assert convert_value_to_string_list(None) == ["None"], (
         "`None` should be coerced via `str(None)` rather than special-cased; "
-        "the ETL relies on a non-null string for `oldValue`/`newValue`."
+        "the ETL relies on a non-null value for `oldValue`/`newValue`."
     )
 
 
-def test_convert_value_to_string_empty_string_passes_through():
-    assert convert_value_to_string("") == "", (
+def test_convert_value_to_string_list_empty_string_passes_through():
+    assert convert_value_to_string_list("") == [""], (
         "Empty strings should remain empty rather than being coerced to another value."
     )
 
@@ -354,11 +357,11 @@ def test_transform_transaction_dict_maps_fields_and_stringifies_values():
         "author_email": "bob@example.com",
         "author_username": "bob",
         "date_created": 1_700_000_000,
-        "old_value": "0",
-        "new_value": "2",
+        "old_value": ["0"],
+        "new_value": ["2"],
     }, (
         "`transform_transaction_dict` should map every column straight "
-        "through, using `convert_value_to_string` on the old/new values."
+        "through, using `convert_value_to_string_list` on the old/new values."
     )
 
 
@@ -378,9 +381,9 @@ def test_transform_transaction_dict_coerces_boolean_values():
         author_username=None,
     )
 
-    assert (result["old_value"], result["new_value"]) == ("0", "1"), (
+    assert (result["old_value"], result["new_value"]) == (["0"], ["1"]), (
         "Boolean `oldValue`/`newValue` should round-trip through "
-        '`convert_value_to_string`, becoming `"0"`/`"1"`.'
+        '`convert_value_to_string_list`, becoming `["0"]`/`["1"]`.'
     )
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,6 +10,11 @@ from types import SimpleNamespace
 import pytest
 
 from phabricator_etl.transforms import (
+    PROJECT_HAS_MEMBER_EDGE_TYPE,
+    decode_name_transaction_value,
+    is_membership_edge_transaction,
+    parse_edge_member_phids,
+    transform_project_transaction_dict,
     convert_value_to_string,
     latest_approved_date,
     latest_landed_date,
@@ -20,6 +25,110 @@ from phabricator_etl.transforms import (
     transform_review_dict,
     transform_transaction_dict,
 )
+
+
+def test_is_membership_edge_transaction_true_for_member_edge():
+    metadata = json.dumps({"edge:type": PROJECT_HAS_MEMBER_EDGE_TYPE})
+    assert is_membership_edge_transaction(metadata) is True
+
+
+def test_is_membership_edge_transaction_false_for_other_edge():
+    # Some non-membership edge type (e.g. watchers).
+    metadata = json.dumps({"edge:type": 42})
+    assert is_membership_edge_transaction(metadata) is False
+
+
+def test_is_membership_edge_transaction_false_for_missing_metadata():
+    assert is_membership_edge_transaction(None) is False
+    assert is_membership_edge_transaction("") is False
+    assert is_membership_edge_transaction(json.dumps({})) is False
+
+
+def test_parse_edge_member_phids_from_dict_snapshot():
+    value = json.dumps(
+        {
+            "PHID-USER-alice": {"dst": "PHID-USER-alice"},
+            "PHID-USER-bob": {"dst": "PHID-USER-bob"},
+        }
+    )
+    assert parse_edge_member_phids(value) == {"PHID-USER-alice", "PHID-USER-bob"}
+
+
+def test_parse_edge_member_phids_from_list_snapshot():
+    value = json.dumps(["PHID-USER-alice", "PHID-USER-bob"])
+    assert parse_edge_member_phids(value) == {"PHID-USER-alice", "PHID-USER-bob"}
+
+
+def test_parse_edge_member_phids_empty_and_null():
+    assert parse_edge_member_phids(None) == set()
+    assert parse_edge_member_phids("") == set()
+    assert parse_edge_member_phids("null") == set()
+
+
+def test_membership_diff_added_and_removed():
+    old = parse_edge_member_phids(
+        json.dumps({"PHID-USER-alice": {}, "PHID-USER-bob": {}})
+    )
+    new = parse_edge_member_phids(
+        json.dumps({"PHID-USER-bob": {}, "PHID-USER-carol": {}})
+    )
+    assert old - new == {"PHID-USER-alice"}  # removed
+    assert new - old == {"PHID-USER-carol"}  # added
+
+
+def test_decode_name_transaction_value():
+    assert decode_name_transaction_value(json.dumps("My Project")) == "My Project"
+    assert decode_name_transaction_value(None) is None
+    assert decode_name_transaction_value("") is None
+    assert decode_name_transaction_value("null") is None
+
+
+def test_transform_project_transaction_dict_shape():
+    transaction = SimpleNamespace(
+        id=99,
+        dateCreated=1700000000,
+        transactionType="core:edge",
+    )
+    row = transform_project_transaction_dict(
+        transaction=transaction,
+        project_id=7,
+        project_name="bmo-reviewers",
+        author_email="alice@example.com",
+        author_username="alice",
+        old_value="bob",
+        new_value="carol",
+    )
+    assert row == {
+        "project_id": 7,
+        "project_name": "bmo-reviewers",
+        "transaction_id": 99,
+        "author_email": "alice@example.com",
+        "author_username": "alice",
+        "date_created": 1700000000,
+        "transaction_type": "core:edge",
+        "old_value": "bob",
+        "new_value": "carol",
+    }
+
+
+def test_transform_project_transaction_dict_create_has_null_values():
+    transaction = SimpleNamespace(
+        id=1,
+        dateCreated=1700000000,
+        transactionType="core:create",
+    )
+    row = transform_project_transaction_dict(
+        transaction=transaction,
+        project_id=7,
+        project_name="bmo-reviewers",
+        author_email=None,
+        author_username=None,
+        old_value=None,
+        new_value=None,
+    )
+    assert row["old_value"] is None
+    assert row["new_value"] is None
+    assert row["transaction_type"] == "core:create"
 
 
 def test_convert_value_to_string_true_becomes_one():


### PR DESCRIPTION
Summary

Added project-transaction tracking to the ETL, populating a new metrics_project_transactions BigQuery table.

phabricator_etl/transforms.py (pure, unit-tested):
- PROJECT_HAS_MEMBER_EDGE_TYPE = 13 constant
- is_membership_edge_transaction() — filters core:edge transactions to membership edges via metadata["edge:type"]
- parse_edge_member_phids() — extracts member PHIDs from a JSON edge snapshot (handles dict, list, null/empty)
- decode_name_transaction_value() — decodes the JSON-encoded project:name value
- transform_project_transaction_dict() — assembles the 9-field row from already-resolved values

phabricator_etl/stats.py:
- New Db ORM class project.Transaction → project_transaction
- PROJECT_TRANSACTION_TYPES = ["core:create", "project:name", "core:edge"]
- New BQ_PROJECT_TRANSACTIONS_TABLE_ID config/env var, wired into load_bigquery_tables and merge_staging_tables (merge key transaction_id)
- get_project_transactions() + helpers get_project() / usernames_for_member_phids(). For membership changes, old_value/new_value hold comma-joined usernames removed/added (the added/removed diff you chose); renames decode the name; core:create carries null values
- Submitted once per run beside get_review_groups (the full-snapshot cadence you chose)

tests/test_transforms.py — 10 new tests

Verification: ruff check, ruff format --check, and pytest (12 passed) all green — run via a sibling venv since this repo pins Python 3.9.16, which isn't installed here.

Two things to flag before this can ship

1. External infra dependency (out of scope for this repo): the actual BigQuery table and its terraform bq_metrics_transactions_schema (the jsonencode([...]) from comment 1) must be created in the infra repo before deploy — this repo only reads existing tables via get_table, so the ETL will raise on startup until BQ_PROJECT_TRANSACTIONS_TABLE_ID points at a real table.
2. date_created is emitted as the raw Phabricator epoch int. BigQuery coerces epoch-seconds into a TIMESTAMP column on insert_rows_json; if the live table rejects it, the fix is a one-line RFC3339 conversion in the transform. Worth confirming on first run against the real table.