### PR TITLE
fix: encode the str PHIDs to bytes before the .in_() filter, matching the bytes PHIDs the rest of the module

### DIFF
--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -731,9 +731,11 @@ def convert_json_to_string_list(value: Any, sessions: Sessions) -> list[str]:
 
     if isinstance(phid_map, dict):
         names = [
-            get_project_name(phid.encode("utf-8"), sessions)
-            if phid.startswith("PHID-PROJ-")
-            else get_user_name(phid.encode("utf-8"), sessions)
+            (
+                get_project_name(phid.encode("utf-8"), sessions)
+                if phid.startswith("PHID-PROJ-")
+                else get_user_name(phid.encode("utf-8"), sessions)
+            )
             for phid in phid_map.keys()
         ]
         return [name for name in names if name is not None]

--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -612,7 +612,7 @@ def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> li
     # that other queries pull straight from the database.
     rows = (
         sessions.users.query(sessions.db.user.User.userName)
-        .filter(sessions.db.user.User.phid.in_(phid.encode() for phid in member_phids))
+        .filter(sessions.db.user.User.phid.in_(phid.encode("utf-8") for phid in member_phids))
         .all()
     )
     return sorted({row[0] for row in rows})

--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -607,9 +607,12 @@ def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> li
     if not member_phids:
         return []
 
+    # `phid` is a binary column, so PHIDs parsed from JSON edge snapshots
+    # (str) must be encoded to bytes before binding, like the bytes PHIDs
+    # that other queries pull straight from the database.
     rows = (
         sessions.users.query(sessions.db.user.User.userName)
-        .filter(sessions.db.user.User.phid.in_(member_phids))
+        .filter(sessions.db.user.User.phid.in_(phid.encode() for phid in member_phids))
         .all()
     )
     return sorted({row[0] for row in rows})

--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -612,7 +612,11 @@ def usernames_for_member_phids(member_phids: set[str], sessions: Sessions) -> li
     # that other queries pull straight from the database.
     rows = (
         sessions.users.query(sessions.db.user.User.userName)
-        .filter(sessions.db.user.User.phid.in_(phid.encode("utf-8") for phid in member_phids))
+        .filter(
+            sessions.db.user.User.phid.in_(
+                phid.encode("utf-8") for phid in member_phids
+            )
+        )
         .all()
     )
     return sorted({row[0] for row in rows})


### PR DESCRIPTION
Summary

Your ETL run crashed in get_project_transactions → usernames_for_member_phids (stats.py:611) with:

```python
TypeError: string argument without an encoding
```

Root cause: Phabricator's user.phid is a binary column. Every other PHID query in the module compares against PHIDs that came out of the database, which are already bytes. But this new code path (added in 8e93bf4, Bug 2047291) gets its member PHIDs from parse_edge_member_phids, which parses them from a JSON edge snapshot — so they're str. When SQLAlchemy bound a str to the binary column it called MySQLdb.Binary → bytes(x), and bytes() on a str with no encoding raises that TypeError.

It only triggered now because this was the first run with core:edge membership transactions that actually resolved member PHIDs — which is why it's tied to the latest commits.

Fix: encode the str PHIDs to bytes before the .in_() filter, matching the bytes PHIDs the rest of the module uses:

```python
.filter(sessions.db.user.User.phid.in_(phid.encode() for phid in member_phids))
```

PHIDs are ASCII, so the default UTF-8 .encode() is safe.
