### PR TITLE
fix: Put back old_value and new_value for transactions to string non-repeated

### DIFF
--- a/phabricator_etl/stats.py
+++ b/phabricator_etl/stats.py
@@ -535,10 +535,10 @@ def get_transactions(revision: Any, sessions: Sessions) -> list[dict]:
         # than a scalar, so resolve the PHIDs to names for readability. This
         # is what surfaces review requests to rotation (project) groups.
         if transaction.transactionType == "differential.revision.reviewers":
-            transaction_obj["old_value"] = convert_json_to_string_list(
+            transaction_obj["old_value"] = convert_json_to_string(
                 transaction.oldValue, sessions
             )
-            transaction_obj["new_value"] = convert_json_to_string_list(
+            transaction_obj["new_value"] = convert_json_to_string(
                 transaction.newValue, sessions
             )
 
@@ -706,20 +706,20 @@ def get_revision(
     }
 
 
-def convert_json_to_string_list(value: Any, sessions: Sessions) -> list[str]:
-    """Convert a JSON-encoded PHID map to a list of names.
+def convert_json_to_string(value: Any, sessions: Sessions) -> str:
+    """Convert a JSON-encoded PHID map to a comma-separated string of names.
 
     Handles the "differential.revision.reviewers" transaction type, whose
     old/new values are JSON objects mapping reviewer PHID -> status (e.g.
     `{"PHID-USER-...": "added"}`). Only the keys (PHIDs) are used; the status
     values are ignored.
 
-    The result is a list of strings so it can populate a REPEATED BigQuery
-    field. Phabricator stores the empty JSON list `[]` when a revision had no
-    prior reviewers, so an empty/falsy value is expected and resolves to `[]`.
-    Any other non-dict shape is unexpected for this transaction type; it is
-    logged and resolved to `[]` rather than writing raw JSON into the analytics
-    column.
+    The result is a single string (resolved names joined by `", "`) so it can
+    populate a STRING BigQuery field. Phabricator stores the empty JSON list
+    `[]` when a revision had no prior reviewers, so an empty/falsy value is
+    expected and resolves to `""`. Any other non-dict shape is unexpected for
+    this transaction type; it is logged and resolved to `""` rather than writing
+    raw JSON into the analytics column.
     """
     try:
         phid_map = json.loads(value)
@@ -733,7 +733,7 @@ def convert_json_to_string_list(value: Any, sessions: Sessions) -> list[str]:
             else get_user_name(phid.encode("utf-8"), sessions)
             for phid in phid_map.keys()
         ]
-        return [name for name in names if name is not None]
+        return ", ".join(name for name in names if name is not None)
 
     if phid_map:
         logging.warning(
@@ -741,7 +741,7 @@ def convert_json_to_string_list(value: Any, sessions: Sessions) -> list[str]:
             type(phid_map).__name__,
             value,
         )
-    return []
+    return ""
 
 
 def get_last_run_timestamp(

--- a/phabricator_etl/transforms.py
+++ b/phabricator_etl/transforms.py
@@ -26,17 +26,17 @@ class PhabricatorEdgeConstant(IntEnum):
     PROJECT_HAS_MEMBER = 13
 
 
-def convert_value_to_string_list(value: Any) -> list[str]:
-    """Coerce a transaction value to a list of strings for a REPEATED field.
+def convert_value_to_string(value: Any) -> str:
+    """Coerce a transaction value to a string for a STRING field.
 
-    If the passed value is a boolean, then we convert it to `["1"]` or
-    `["0"]`. Otherwise we wrap its string form in a single-element list.
+    If the passed value is a boolean, then we convert it to `"1"` or
+    `"0"`. Otherwise we return its string form.
     """
     if isinstance(value, bool):
-        # `["1"]` for `True`, `["0"]` for `False`.
-        return [str(int(value))]
+        # `"1"` for `True`, `"0"` for `False`.
+        return str(int(value))
 
-    return [str(value)]
+    return str(value)
 
 
 def transform_changeset_dict(
@@ -101,8 +101,8 @@ def transform_transaction_dict(
         "author_email": author_email,
         "author_username": author_username,
         "date_created": transaction.dateCreated,
-        "old_value": convert_value_to_string_list(transaction.oldValue),
-        "new_value": convert_value_to_string_list(transaction.newValue),
+        "old_value": convert_value_to_string(transaction.oldValue),
+        "new_value": convert_value_to_string(transaction.newValue),
     }
 
 

--- a/tests/test_convert_json_to_string.py
+++ b/tests/test_convert_json_to_string.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Tests for `convert_json_to_string_list`, which resolves the JSON PHID->status
-maps stored on `differential.revision.reviewers` transactions into a list of
-reviewer names.
+"""Tests for `convert_json_to_string`, which resolves the JSON PHID->status
+maps stored on `differential.revision.reviewers` transactions into a single
+comma-separated string of reviewer names.
 
 The fixtures below use real `oldValue`/`newValue` strings observed in the
 Phabricator `differential_transaction` table. The reviewer name lookups are
@@ -20,7 +20,7 @@ import pytest
 from phabricator_etl import stats
 
 # Names keyed by the PHIDs that appear in the sample data below. Keys are
-# bytes because `convert_json_to_string_list` encodes each PHID before lookup.
+# bytes because `convert_json_to_string` encodes each PHID before lookup.
 USER_NAMES = {
     b"PHID-USER-m4uq3un4hnoj4j35o7xc": "alice",
     b"PHID-USER-zcy2d375tpinr3tfxa3d": "bob",
@@ -55,9 +55,9 @@ def sessions():
 # --- value -> output -----------------------------------------------------
 #
 # Each case feeds a stored `oldValue`/`newValue` string through the function
-# and asserts the list of reviewer names it produces. The empty/fallback
-# inputs that resolve to `[]` live here too; their *logging* behaviour is
-# exercised separately below.
+# and asserts the comma-separated string of reviewer names it produces. The
+# empty/fallback inputs that resolve to `""` live here too; their *logging*
+# behaviour is exercised separately below.
 
 
 @pytest.mark.parametrize(
@@ -65,20 +65,20 @@ def sessions():
     [
         pytest.param(
             '{"PHID-USER-m4uq3un4hnoj4j35o7xc":"added"}',
-            ["alice"],
+            "alice",
             "a single reviewer PHID resolves to its user name",
             id="single-reviewer",
         ),
         pytest.param(
             '{"PHID-USER-qsqyz242anhk5zywnmik":"added",'
             '"PHID-USER-n77lkspun6bajdj6gwx4":"added"}',
-            ["carol", "dave"],
-            "multiple reviewers are listed in the JSON key order",
+            "carol, dave",
+            "multiple reviewers are joined in the JSON key order",
             id="multiple-reviewers-preserve-order",
         ),
         pytest.param(
             '{"PHID-USER-m4uq3un4hnoj4j35o7xc":"accepted"}',
-            ["alice"],
+            "alice",
             "only the PHID keys matter; the status value is not surfaced",
             id="status-value-is-ignored",
         ),
@@ -87,50 +87,50 @@ def sessions():
             '"PHID-USER-n77lkspun6bajdj6gwx4":"added",'
             '"PHID-USER-m4uq3un4hnoj4j35o7xc":"added",'
             '"PHID-USER-myoawqp3kpkeeedt764l":"added"}',
-            ["erin", "dave", "alice", "frank"],
+            "erin, dave, alice, frank",
             "four reviewers all resolve and stay in key order",
             id="four-reviewers",
         ),
         pytest.param(
             '{"PHID-PROJ-rotationgroupxxxxxxx":"added"}',
-            ["sheriffs"],
+            "sheriffs",
             "PHID-PROJ-* keys resolve via the project cache, not the user cache",
             id="project-phid-resolves-via-project-cache",
         ),
         pytest.param(
             '{"PHID-USER-m4uq3un4hnoj4j35o7xc":"added",'
             '"PHID-USER-unknownnnnnnnnnnnnnn":"added"}',
-            ["alice"],
-            "a PHID resolving to None is dropped from the output list",
+            "alice",
+            "a PHID resolving to None is dropped from the output string",
             id="unresolved-phid-is-dropped",
         ),
         pytest.param(
             "[]",
-            [],
-            "Phabricator's empty-reviewers `[]` becomes an empty list",
+            "",
+            "Phabricator's empty-reviewers `[]` becomes an empty string",
             id="empty-list",
         ),
         pytest.param(
             "not json at all",
-            [],
-            "unparseable input falls back to an empty list",
+            "",
+            "unparseable input falls back to an empty string",
             id="malformed-json",
         ),
         pytest.param(
             None,
-            [],
-            "non-string input (json.loads raises TypeError) falls back to []",
+            "",
+            "non-string input (json.loads raises TypeError) falls back to ''",
             id="non-string-input",
         ),
     ],
 )
 def test_value_converts_to_reviewer_names(sessions, value, expected, intent):
-    assert stats.convert_json_to_string_list(value, sessions) == expected, intent
+    assert stats.convert_json_to_string(value, sessions) == expected, intent
 
 
 # --- warning vs. no-warning ----------------------------------------------
 #
-# Every case still resolves to `[]`. They differ only in whether the function
+# Every case still resolves to `""`. They differ only in whether the function
 # logs a warning: expected/fallback inputs stay quiet, while a non-empty,
 # non-dict JSON value is logged for visibility. `extra_substring`, when set,
 # is an additional fragment expected in the log (e.g. the offending type).
@@ -143,35 +143,35 @@ def test_value_converts_to_reviewer_names(sessions, value, expected, intent):
             "[]",
             False,
             None,
-            "the expected empty-reviewers `[]` resolves to [] without warning",
+            "the expected empty-reviewers `[]` resolves to '' without warning",
             id="empty-list-no-warning",
         ),
         pytest.param(
             "not json at all",
             False,
             None,
-            "malformed JSON resolves to [] without warning",
+            "malformed JSON resolves to '' without warning",
             id="malformed-json-no-warning",
         ),
         pytest.param(
             None,
             False,
             None,
-            "non-string input resolves to [] without warning",
+            "non-string input resolves to '' without warning",
             id="non-string-no-warning",
         ),
         pytest.param(
             '["PHID-USER-m4uq3un4hnoj4j35o7xc"]',
             True,
             "list",
-            "an unexpected non-empty JSON list resolves to [] and is logged",
+            "an unexpected non-empty JSON list resolves to '' and is logged",
             id="unexpected-list-warns",
         ),
         pytest.param(
             "42",
             True,
             None,
-            "an unexpected JSON scalar resolves to [] and is logged",
+            "an unexpected JSON scalar resolves to '' and is logged",
             id="unexpected-scalar-warns",
         ),
     ],
@@ -180,7 +180,7 @@ def test_warning_emitted_only_for_unexpected_json(
     sessions, caplog, value, expects_warning, extra_substring, intent
 ):
     with caplog.at_level(logging.WARNING):
-        assert stats.convert_json_to_string_list(value, sessions) == [], intent
+        assert stats.convert_json_to_string(value, sessions) == "", intent
 
     if not expects_warning:
         assert caplog.records == [], intent

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,7 +15,7 @@ from phabricator_etl.transforms import (
     is_membership_edge_transaction,
     parse_edge_member_phids,
     transform_project_transaction_dict,
-    convert_value_to_string_list,
+    convert_value_to_string,
     latest_approved_date,
     latest_landed_date,
     parse_repository_details,
@@ -134,41 +134,41 @@ def test_transform_project_transaction_dict_create_has_new_name_only():
     assert row["transaction_type"] == "core:create"
 
 
-def test_convert_value_to_string_list_true_becomes_one():
-    assert convert_value_to_string_list(True) == ["1"], (
-        '`convert_value_to_string_list(True)` should return `["1"]` so that '
-        "boolean transaction values round-trip into BigQuery's REPEATED column."
+def test_convert_value_to_string_true_becomes_one():
+    assert convert_value_to_string(True) == "1", (
+        '`convert_value_to_string(True)` should return `"1"` so that '
+        "boolean transaction values round-trip into BigQuery's STRING column."
     )
 
 
-def test_convert_value_to_string_list_false_becomes_zero():
-    assert convert_value_to_string_list(False) == ["0"], (
-        '`convert_value_to_string_list(False)` should return `["0"]` '
+def test_convert_value_to_string_false_becomes_zero():
+    assert convert_value_to_string(False) == "0", (
+        '`convert_value_to_string(False)` should return `"0"` '
         "(the string, not the integer)."
     )
 
 
-def test_convert_value_to_string_list_str_passes_through():
-    assert convert_value_to_string_list("already a string") == ["already a string"], (
-        "A string input should be wrapped in a single-element list unchanged."
+def test_convert_value_to_string_str_passes_through():
+    assert convert_value_to_string("already a string") == "already a string", (
+        "A string input should pass through unchanged."
     )
 
 
-def test_convert_value_to_string_list_int_stringifies():
-    assert convert_value_to_string_list(42) == ["42"], (
+def test_convert_value_to_string_int_stringifies():
+    assert convert_value_to_string(42) == "42", (
         "Integer inputs should be coerced to their decimal string form."
     )
 
 
-def test_convert_value_to_string_list_none_stringifies():
-    assert convert_value_to_string_list(None) == ["None"], (
+def test_convert_value_to_string_none_stringifies():
+    assert convert_value_to_string(None) == "None", (
         "`None` should be coerced via `str(None)` rather than special-cased; "
         "the ETL relies on a non-null value for `oldValue`/`newValue`."
     )
 
 
-def test_convert_value_to_string_list_empty_string_passes_through():
-    assert convert_value_to_string_list("") == [""], (
+def test_convert_value_to_string_empty_string_passes_through():
+    assert convert_value_to_string("") == "", (
         "Empty strings should remain empty rather than being coerced to another value."
     )
 
@@ -357,11 +357,11 @@ def test_transform_transaction_dict_maps_fields_and_stringifies_values():
         "author_email": "bob@example.com",
         "author_username": "bob",
         "date_created": 1_700_000_000,
-        "old_value": ["0"],
-        "new_value": ["2"],
+        "old_value": "0",
+        "new_value": "2",
     }, (
         "`transform_transaction_dict` should map every column straight "
-        "through, using `convert_value_to_string_list` on the old/new values."
+        "through, using `convert_value_to_string` on the old/new values."
     )
 
 
@@ -381,9 +381,9 @@ def test_transform_transaction_dict_coerces_boolean_values():
         author_username=None,
     )
 
-    assert (result["old_value"], result["new_value"]) == (["0"], ["1"]), (
+    assert (result["old_value"], result["new_value"]) == ("0", "1"), (
         "Boolean `oldValue`/`newValue` should round-trip through "
-        '`convert_value_to_string_list`, becoming `["0"]`/`["1"]`.'
+        '`convert_value_to_string`, becoming `"0"`/`"1"`.'
     )
 
 


### PR DESCRIPTION
Summary

Verified your claim: Yes — both tables' transaction-building code emitted lists (repeated strings). The Terraform schema confirms transactions wants single STRING while project_transactions wants STRING REPEATED.

Changes made (transactions table → single string):

- phabricator_etl/transforms.py
  - convert_value_to_string_list → convert_value_to_string: now returns a plain str (True/False → "1"/"0", everything else str(value)) instead of wrapping in a list.
  - transform_transaction_dict: calls the renamed helper, so old_value/new_value are scalars.
- phabricator_etl/stats.py
  - convert_json_to_string_list → convert_json_to_string: for the differential.revision.reviewers type, resolved reviewer names are now joined with ", " into one string (empty/fallback inputs → "").
  - Updated the two call sites in get_transactions.
- Tests updated to match: tests/test_transforms.py (import + assertions) and renamed tests/test_convert_json_to_string_list.py → tests/test_convert_json_to_string.py with string expectations.

Left untouched: transform_project_transaction_dict and the project-transaction value resolution in stats.py — those correctly remain lists for the REPEATED schema.
